### PR TITLE
remove redundant envfrom

### DIFF
--- a/templates/backstage/sidecar-setup.yaml
+++ b/templates/backstage/sidecar-setup.yaml
@@ -9,8 +9,6 @@ containers:
         value: rhdh
     envFrom:
       - secretRef:
-          name: provider-keys
-      - secretRef:
           name: sed.edit.RHDH_SECRETS_NAME
     image: sed.edit.RCS_IMAGE
     name: road-core-sidecar


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Removes the redundant envFrom for the provider keys. Since this secret contains a bunch of .txt files used for storing keys so that RCS can read them if you need, they won't be read as environment variables and the file will be skipped anyway.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

N/A

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

### How to test changes / Special notes to the reviewer:

I removed the reference and deployed the sidecar and everything worked as expected. I also tested it in the scenario when you don't use RHDH secrets so the `envFrom` would be empty, still functioned as expected as Kubernetes/OC does not care if an array is empty