### PR TITLE
Copy rag-content to vol, mount vol in LLS container

### DIFF
--- a/env/default-values
+++ b/env/default-values
@@ -11,3 +11,7 @@ export LCS_IMAGE=
 # [OPTIONAL] This is the image registry where your built Llama Stack image is located.
 # If unset, defaults to: quay.io/redhat-ai-dev/llama-stack:latest
 export LLS_IMAGE=
+
+# [OPTIONAL] This is the image registry where your built RHDH RAG data is located.
+# If unset, defaults to: quay.io/redhat-ai-dev/rag-content:release-1.7-lcs
+export RAG_IMAGE=

--- a/templates/backstage/sidecar-setup.yaml
+++ b/templates/backstage/sidecar-setup.yaml
@@ -1,4 +1,14 @@
 ---
+initContainers:
+  - name: init-rag-data
+    image: sed.edit.RAG_IMAGE
+    command:
+      - "sh"
+      - "-c"
+      - "echo 'Copying RAG data...'; cp -r /rag/vector_db/rhdh_product_docs /data/ && cp -r /rag/embeddings_model /data/ && echo 'Copy complete.'"
+    volumeMounts:
+      - mountPath: /data
+        name: rag-data-volume
 containers:
   - envFrom:
     - secretRef:
@@ -8,6 +18,12 @@ containers:
     volumeMounts:
       - mountPath: /app-root/.llama
         name: shared-storage
+      - mountPath: /app-root/embeddings_model
+        name: rag-data-volume
+        subPath: embeddings_model
+      - mountPath: /app-root/vector_db/rhdh_product_docs
+        name: rag-data-volume
+        subPath: rhdh_product_docs
     # LLAMA_OVERRIDE_MOUNT_START
       - mountPath: /app-root/run.yaml
         subPath: run.yaml
@@ -27,6 +43,8 @@ volumes:
     name: lightspeed-stack
   - emptyDir: {}
     name: shared-storage
+  - emptyDir: {}
+    name: rag-data-volume
   # LLAMA_OVERRIDE_VOLUME_START
   - configMap:
       name: llama-stack-config


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
- Init new empty dir rag volume
- Init container copies rag content and embedding model from rag-content image to rag volume
- LLS container then mounts the volume

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->
https://issues.redhat.com/browse/RHDHPAI-985

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [x] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

### How to test changes / Special notes to the reviewer:

To test streaming_query RAG, your LLS image needs to have https://github.com/redhat-ai-dev/llama-stack/pull/5. Otherwise, your LLS container will just mount the rag-content but do nothing with it.

Here is the Init Container Log:
<img width="784" height="493" alt="Screenshot 2025-09-18 at 7 48 44 PM" src="https://github.com/user-attachments/assets/c793f307-0205-4e71-b07d-3408ecfa8308" />

Here is the output of streaming_query where I asked, "What are the benefits of Red Hat Developer Hub?":
<img width="1200" height="581" alt="Screenshot 2025-09-18 at 7 51 24 PM" src="https://github.com/user-attachments/assets/5ae5d8e9-9324-41a6-a9a5-e22e0d45404c" />
